### PR TITLE
Fix config precedence, panic paths, stale-CRL trust, and other bugs + cleanups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,6 +1832,7 @@ dependencies = [
  "anyhow",
  "clap",
  "comfy-table",
+ "idna",
  "openssl",
  "prometheus",
  "reqwest 0.13.4",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1832,7 +1832,6 @@ dependencies = [
  "anyhow",
  "clap",
  "comfy-table",
- "lazy_static",
  "openssl",
  "prometheus",
  "reqwest 0.13.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ serde = { version = "1.0.228", features = ["derive"] }
 comfy-table = "7.2.2"
 strum = "0.28.0"
 strum_macros = "0.28.0"
-lazy_static = "1.5.0"
 url = "2.5.8"
 reqwest = { version = "0.13.4", features = ["blocking", "json"] }
 toml = "1.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "tlschecker"
 version = "1.1.1"
-edition = "2018"
+edition = "2021"
 rust-version = "1.77.0"                                                    # MSRV
 description = "Experimental TLS/SSL certificate checker from command line"
 authors = ["Jose Bovet Derpich <jose.bovet@gmail.com>"]
-license = "GNU"
+license = "GPL-3.0-only"
 readme = "README.md"
 repository = "https://github.com/jbovet/tlschecker"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,9 @@ comfy-table = "7.2.2"
 strum = "0.28.0"
 strum_macros = "0.28.0"
 url = "2.5.8"
+# Already in the dependency tree via `url`; used directly for IDN -> A-label
+# (punycode) hostname conversion.
+idna = "1.1.0"
 reqwest = { version = "0.13.4", features = ["blocking", "json"] }
 toml = "1.1.2"
 tempfile = "3.27.0"

--- a/README.md
+++ b/README.md
@@ -220,15 +220,22 @@ You can use a TOML configuration file to check multiple hosts. Create a file lik
 hosts = [
     "example.com",
     "example.com:8443",
-    "secure-service.internal:9443"
+    "secure-service.internal:9443",
 ]
 
 # Optional settings
+output = "summary"
+exit_code = 1
 check_revocation = true
-output_format = "json"
-prometheus = false
-prometheus_address = "http://localhost:9091"
+grade = false
+min_validity = 30
+
+[prometheus]
+enabled = false
+address = "http://localhost:9091"
 ```
+
+You can also generate a commented example with `tlschecker --generate-config`.
 
 Then run TLSChecker with the config file:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -940,6 +940,15 @@ pub fn check_crl_status(cert: &X509, chain: &[X509]) -> Result<RevocationStatus,
             continue; // CRL signature verification failed
         }
 
+        // Reject stale CRLs: a correctly-signed but expired CRL (nextUpdate in
+        // the past) may predate a revocation, so trusting it could mask a
+        // revoked certificate — e.g. an on-path attacker replaying an old CRL.
+        // Skipping degrades to `Unknown`, mirroring the OCSP
+        // verification-failure handling.
+        if !is_crl_fresh(&crl, crl_url) {
+            continue;
+        }
+
         // Check if the certificate is in the CRL
         match crl.get_by_cert(cert) {
             CrlStatus::Revoked(revoked) => {
@@ -966,6 +975,36 @@ pub fn check_crl_status(cert: &X509, chain: &[X509]) -> Result<RevocationStatus,
 
     // If we've tried all CRLs and none worked or none contained information about this certificate
     Ok(RevocationStatus::Unknown)
+}
+
+/// Checks whether a CRL is still fresh enough to be trusted.
+///
+/// Returns `false` when `nextUpdate` lies in the past — a correctly-signed but
+/// stale CRL may predate a revocation and must not be relied upon. `nextUpdate`
+/// is optional per RFC 5280; when absent the CRL is accepted (returns `true`)
+/// but a warning is logged, since freshness cannot be established. `source` is
+/// only used to make the log messages actionable.
+fn is_crl_fresh(crl: &X509Crl, source: &str) -> bool {
+    match crl.next_update() {
+        Some(next_update) => {
+            if has_expired(next_update) {
+                warn!(
+                    "CRL from {} is stale (nextUpdate {} is in the past); ignoring it",
+                    source, next_update
+                );
+                false
+            } else {
+                true
+            }
+        }
+        None => {
+            warn!(
+                "CRL from {} carries no nextUpdate; accepting it but freshness cannot be verified",
+                source
+            );
+            true
+        }
+    }
 }
 
 impl TLS {
@@ -2057,6 +2096,67 @@ mod tests {
         builder.sign(&pkey, MessageDigest::sha256()).unwrap();
 
         (builder.build(), pkey)
+    }
+
+    /// Builds a signed CRL whose `nextUpdate` is `next_update_offset_secs`
+    /// from now (negative = already stale). The builder requires an AKID,
+    /// a CRL number, and at least one revoked entry, so those are included.
+    fn make_test_crl(next_update_offset_secs: i64) -> openssl::x509::X509Crl {
+        use openssl::x509::extension::AuthorityKeyIdentifier;
+        use openssl::x509::{CrlNumber, X509CrlBuilder, X509RevokedBuilder};
+
+        let (issuer_cert, issuer_key) = make_test_x509("Test CA");
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        let mut revoked = X509RevokedBuilder::new().unwrap();
+        revoked
+            .set_serial_number(&BigNum::from_u32(1024).unwrap().to_asn1_integer().unwrap())
+            .unwrap();
+        revoked
+            .set_revocation_date(&Asn1Time::from_unix(now - 86_400).unwrap())
+            .unwrap();
+
+        let dummy = X509Builder::new().unwrap();
+        let ctx = dummy.x509v3_context(Some(issuer_cert.as_ref()), None);
+        let aki = AuthorityKeyIdentifier::new()
+            .issuer(true)
+            .build(&ctx)
+            .unwrap();
+        let crl_number = CrlNumber::new(BigNum::from_u32(1).unwrap())
+            .unwrap()
+            .build()
+            .unwrap();
+
+        let mut builder = X509CrlBuilder::new().unwrap();
+        builder.set_issuer_name(issuer_cert.subject_name()).unwrap();
+        builder
+            .set_last_update(&Asn1Time::from_unix(now - 7 * 86_400).unwrap())
+            .unwrap();
+        builder
+            .set_next_update(&Asn1Time::from_unix(now + next_update_offset_secs).unwrap())
+            .unwrap();
+        builder.append_extension(aki).unwrap();
+        builder.append_extension(crl_number).unwrap();
+        builder.add_revoked(revoked.build()).unwrap();
+        builder.sign(&issuer_key, MessageDigest::sha256()).unwrap();
+        builder.build().unwrap()
+    }
+
+    #[test]
+    fn test_stale_crl_is_rejected() {
+        // nextUpdate a day in the past -> stale, must not be trusted.
+        let crl = make_test_crl(-86_400);
+        assert!(!crate::is_crl_fresh(&crl, "test"));
+    }
+
+    #[test]
+    fn test_fresh_crl_is_accepted() {
+        // nextUpdate a week in the future -> fresh.
+        let crl = make_test_crl(7 * 86_400);
+        assert!(crate::is_crl_fresh(&crl, "test"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -929,8 +929,14 @@ pub fn check_crl_status(cert: &X509, chain: &[X509]) -> Result<RevocationStatus,
             }
         };
 
-        // Verify the CRL signature
-        if crl.verify(&issuer.public_key().unwrap()).is_err() {
+        // Verify the CRL signature. An issuer whose public key cannot be
+        // extracted is treated like a failed verification: skip this CRL
+        // (degrading to `Unknown`) rather than panicking.
+        let issuer_key = match issuer.public_key() {
+            Ok(key) => key,
+            Err(_) => continue,
+        };
+        if crl.verify(&issuer_key).is_err() {
             continue; // CRL signature verification failed
         }
 
@@ -1194,10 +1200,12 @@ impl TLS {
 fn from_entries(mut entries: X509NameEntries) -> String {
     match entries.next() {
         None => "None".to_string(),
-        Some(x509_name_ref) => x509_name_ref
-            .data()
-            .to_string()
-            .expect("Failed to convert data to UTF-8"),
+        // A certificate under inspection may carry non-UTF-8 name entries;
+        // degrade to a lossy conversion instead of panicking on it.
+        Some(x509_name_ref) => match x509_name_ref.data().to_string() {
+            Ok(s) => s,
+            Err(_) => String::from_utf8_lossy(x509_name_ref.data().as_slice()).into_owned(),
+        },
     }
 }
 
@@ -1293,7 +1301,11 @@ fn get_certificate_info(cert_ref: &X509) -> CertificateInfo {
         validity_days: get_validity_days(cert_ref.not_after()),
         validity_hours: get_validity_in_hours(cert_ref.not_after()),
         is_expired: has_expired(cert_ref.not_after()),
-        cert_sn: cert_ref.serial_number().to_bn().unwrap().to_string(),
+        cert_sn: cert_ref
+            .serial_number()
+            .to_bn()
+            .map(|bn| bn.to_string())
+            .unwrap_or_else(|_| "Unknown".to_string()),
         cert_ver: cert_ref.version().to_string(),
         cert_alg: cert_ref.signature_algorithm().object().to_string(),
         sans,
@@ -1326,7 +1338,26 @@ fn fingerprint(cert_ref: &X509, digest: openssl::hash::MessageDigest) -> String 
     }
 }
 
+/// Computes the time remaining until certificate expiration.
+///
+/// Returns the openssl `TimeDiff` (days + leftover seconds, both negative when
+/// already expired), or `None` if the current time or the diff cannot be
+/// computed — callers degrade to zero rather than panicking.
+fn validity_diff(not_after: &Asn1TimeRef) -> Option<openssl::asn1::TimeDiff> {
+    let now = Asn1Time::days_from_now(0).ok()?;
+    match now.deref().diff(not_after) {
+        Ok(diff) => Some(diff),
+        Err(_) => {
+            warn!("Failed to compute certificate validity period");
+            None
+        }
+    }
+}
+
 /// Calculates the number of hours until certificate expiration.
+///
+/// Unlike `days * 24`, this includes the sub-day remainder, so a certificate
+/// expiring in 10 hours reports 10 rather than 0.
 ///
 /// # Arguments
 ///
@@ -1336,7 +1367,9 @@ fn fingerprint(cert_ref: &X509, digest: openssl::hash::MessageDigest) -> String 
 ///
 /// Number of hours until expiration (negative if already expired).
 fn get_validity_in_hours(not_after: &Asn1TimeRef) -> i32 {
-    get_validity_days(not_after) * 24
+    validity_diff(not_after)
+        .map(|diff| diff.days * 24 + diff.secs / 3600)
+        .unwrap_or(0)
 }
 
 /// Calculates the number of days until certificate expiration.
@@ -1349,12 +1382,7 @@ fn get_validity_in_hours(not_after: &Asn1TimeRef) -> i32 {
 ///
 /// Number of days until expiration (negative if already expired).
 fn get_validity_days(not_after: &Asn1TimeRef) -> i32 {
-    Asn1Time::days_from_now(0)
-        .unwrap()
-        .deref()
-        .diff(not_after)
-        .unwrap()
-        .days
+    validity_diff(not_after).map(|diff| diff.days).unwrap_or(0)
 }
 
 /// Checks whether a certificate has expired.
@@ -1973,10 +2001,11 @@ mod tests {
         assert!(!tls_result.certificate.is_expired);
         assert!(tls_result.certificate.validity_days > 0);
         assert!(tls_result.certificate.validity_hours > 0);
-        assert_eq!(
-            tls_result.certificate.validity_hours,
-            tls_result.certificate.validity_days * 24
-        );
+        // Hours include the sub-day remainder, so they fall between the whole
+        // days and the next full day.
+        let days = tls_result.certificate.validity_days;
+        let hours = tls_result.certificate.validity_hours;
+        assert!(hours >= days * 24 && hours < (days + 1) * 24);
     }
 
     #[test]
@@ -2028,6 +2057,25 @@ mod tests {
         builder.sign(&pkey, MessageDigest::sha256()).unwrap();
 
         (builder.build(), pkey)
+    }
+
+    #[test]
+    fn test_validity_hours_includes_subday_remainder() {
+        // A certificate expiring in ~10 hours must report 0 days but ~10
+        // hours (regression: hours used to be computed as days * 24).
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        let not_after = Asn1Time::from_unix(now + 10 * 3600).unwrap();
+
+        assert_eq!(crate::get_validity_days(&not_after), 0);
+        let hours = crate::get_validity_in_hours(&not_after);
+        assert!(
+            (9..=10).contains(&hours),
+            "expected ~10 hours remaining, got {}",
+            hours
+        );
     }
 
     /// Creates a certificate signed by an issuer (not self-signed).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -432,7 +432,9 @@ fn is_chain_well_ordered(chain: &[X509]) -> bool {
 ///
 /// `true` if the certificate is valid for the hostname, `false` otherwise.
 pub fn cert_matches_hostname(hostname: &str, cert: &X509) -> bool {
-    let hostname = hostname.trim_end_matches('.').to_ascii_lowercase();
+    // Certificates carry DNS names in ASCII A-label form; convert an IDN
+    // input (e.g. "bücher.example") before comparing.
+    let hostname = to_ascii_hostname(hostname.trim_end_matches('.')).to_ascii_lowercase();
     if hostname.is_empty() {
         return false;
     }
@@ -500,6 +502,21 @@ pub(crate) fn unbracket_host(host: &str) -> &str {
     host.strip_prefix('[')
         .and_then(|h| h.strip_suffix(']'))
         .unwrap_or(host)
+}
+
+/// Converts an internationalized (IDN) hostname to its ASCII A-label
+/// (punycode) form, e.g. `bücher.example` -> `xn--bcher-kva.example`.
+///
+/// Certificates carry SAN entries in A-label form, and DNS resolution likewise
+/// expects ASCII, so user-supplied unicode hostnames are converted before
+/// matching or resolving. Already-ASCII input is returned unchanged, and a
+/// failed conversion falls back to the original string (which will then fail
+/// resolution/matching with the user's own spelling in the message).
+pub(crate) fn to_ascii_hostname(host: &str) -> String {
+    if host.is_ascii() {
+        return host.to_string();
+    }
+    idna::domain_to_ascii(host).unwrap_or_else(|_| host.to_string())
 }
 
 /// Matches a single certificate DNS name (which may be a wildcard) against a
@@ -1021,8 +1038,11 @@ impl TLS {
 
         // Trim any whitespace, and strip brackets that wrap IPv6 literals
         // (e.g. "[::1]" -> "::1") so address resolution and hostname matching
-        // both operate on a bare address.
-        let host = unbracket_host(host.trim());
+        // both operate on a bare address. Internationalized hostnames are
+        // converted to their ASCII A-label (punycode) form, which is what both
+        // DNS and certificate SAN entries use.
+        let host = to_ascii_hostname(unbracket_host(host.trim()));
+        let host = host.as_str();
 
         // Validate hostname is not empty
         if host.is_empty() {
@@ -2466,6 +2486,31 @@ mod tests {
         let cert = make_test_x509_with_sans("cn.example.com", &["san.example.com"]);
         assert!(super::cert_matches_hostname("san.example.com", &cert));
         assert!(!super::cert_matches_hostname("cn.example.com", &cert));
+    }
+
+    #[test]
+    fn test_cert_matches_hostname_idn() {
+        // Certificates carry SANs in A-label (punycode) form; a unicode input
+        // hostname must be converted before matching.
+        let cert = make_test_x509_with_sans(
+            "xn--bcher-kva.example",
+            &["xn--bcher-kva.example", "*.xn--bcher-kva.example"],
+        );
+        assert!(super::cert_matches_hostname("bücher.example", &cert));
+        assert!(super::cert_matches_hostname("www.bücher.example", &cert));
+        assert!(!super::cert_matches_hostname("bücherei.example", &cert));
+        // The A-label form itself still matches, of course.
+        assert!(super::cert_matches_hostname("xn--bcher-kva.example", &cert));
+    }
+
+    #[test]
+    fn test_to_ascii_hostname() {
+        assert_eq!(
+            super::to_ascii_hostname("bücher.example"),
+            "xn--bcher-kva.example"
+        );
+        // ASCII input passes through unchanged.
+        assert_eq!(super::to_ascii_hostname("example.com"), "example.com");
     }
 
     /// Creates a self-signed cert with the given iPAddress SANs (plus optional

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,16 @@ struct Args {
     #[arg(long)]
     export_pem: bool,
 
+    /// Treat hosts that could not be checked at all as failures for
+    /// exit-code purposes.
+    ///
+    /// By default an unreachable host (DNS failure, refused connection,
+    /// handshake error, invalid address) is only logged and does not affect
+    /// the exit code. With this flag, any such error makes the run exit with
+    /// --exit-code, so CI pipelines can catch hosts that are down entirely.
+    #[arg(long)]
+    fail_on_error: bool,
+
     /// Look the presented leaf certificate up in public Certificate
     /// Transparency logs (via crt.sh).
     ///
@@ -643,6 +653,7 @@ impl FormatterFactory {
 ///
 /// Represents the result of parsing a host address specification,
 /// which may include a port number or use the default port 443.
+#[derive(Debug)]
 struct HostPort {
     /// Hostname or IP address (IPv6 brackets are removed)
     host: String,
@@ -740,12 +751,19 @@ fn main() -> Result<()> {
     let exit_code = final_config.exit_code;
     let mut failed_result = false;
 
-    // Parse hosts and ports
-    let hosts_and_ports: Vec<HostPort> = final_config
-        .addresses
-        .iter()
-        .map(|address| parse_host_port(address))
-        .collect();
+    // Parse hosts and ports; invalid addresses are reported and counted as
+    // errored hosts rather than silently checked as bogus hostnames.
+    let mut error_count: usize = 0;
+    let mut hosts_and_ports: Vec<HostPort> = Vec::with_capacity(final_config.addresses.len());
+    for address in &final_config.addresses {
+        match parse_host_port(address) {
+            Ok(host_port) => hosts_and_ports.push(host_port),
+            Err(msg) => {
+                error!("Skipping '{}': {}", address, msg);
+                error_count += 1;
+            }
+        }
+    }
 
     let hosts_len = hosts_and_ports.len();
     let check_revocation = final_config.check_revocation;
@@ -846,9 +864,10 @@ fn main() -> Result<()> {
     for handle in handles {
         match handle.join() {
             Ok(Some(tls_result)) => results.push(tls_result),
-            Ok(None) => {} // Error already logged inside the thread
+            Ok(None) => error_count += 1, // Error already logged inside the thread
             Err(panic_err) => {
                 error!("A worker thread panicked unexpectedly: {:?}", panic_err);
+                error_count += 1;
             }
         }
     }
@@ -871,6 +890,12 @@ fn main() -> Result<()> {
         .collect::<Vec<_>>();
 
     if !expired_certs.is_empty() || !revoked_certs.is_empty() {
+        failed_result = true;
+    }
+
+    // With --fail-on-error, hosts that could not be checked at all (invalid
+    // address, DNS failure, connection/handshake error) count as failures.
+    if cli.fail_on_error && error_count > 0 {
         failed_result = true;
     }
 
@@ -1018,14 +1043,16 @@ fn should_grade(config_grade: bool, scan: bool) -> bool {
 ///
 /// # Returns
 ///
-/// A `HostPort` struct containing the extracted hostname and optional port.
+/// `Ok(HostPort)` with the extracted hostname and optional port, or an error
+/// message when the address carries a port specification that is not a valid
+/// port number (e.g. `example.com:99999`).
 ///
 /// # Note
 ///
 /// - IPv6 brackets are automatically removed from the hostname
 /// - If no port is specified, returns `None` for the port (defaults to 443)
 /// - URL schemes (http://, https://) are stripped and ignored
-fn parse_host_port(address: &str) -> HostPort {
+fn parse_host_port(address: &str) -> Result<HostPort, String> {
     // Try to fix common user mistakes by adding https:// if missing a scheme
     let address_with_scheme = if !address.contains("://") {
         format!("https://{}", address)
@@ -1037,10 +1064,10 @@ fn parse_host_port(address: &str) -> HostPort {
     if let Ok(url) = Url::parse(&address_with_scheme) {
         // If it's a valid URL, extract host and port
         if let Some(host_str) = url.host_str() {
-            return HostPort {
+            return Ok(HostPort {
                 host: host_str.to_string(),
                 port: url.port(),
-            };
+            });
         }
     }
 
@@ -1050,20 +1077,29 @@ fn parse_host_port(address: &str) -> HostPort {
         if let Ok(port) = port_str.parse::<u16>() {
             // Make sure we don't include IPv6 brackets in the hostname
             let clean_host = host.trim_start_matches('[').trim_end_matches(']');
-            return HostPort {
+            return Ok(HostPort {
                 host: clean_host.to_string(),
                 port: Some(port),
-            };
+            });
+        }
+        // The segment after the colon was clearly meant as a port but is not a
+        // valid one; report it instead of silently treating "host:99999" as a
+        // hostname (which would only surface later as a confusing DNS error).
+        if !port_str.is_empty() && port_str.chars().all(|c| c.is_ascii_digit()) {
+            return Err(format!(
+                "Invalid port '{}' in address '{}' (ports must be 1-65535)",
+                port_str, address
+            ));
         }
     }
 
     // No port specified, just a hostname
     // For IPv6 addresses, clean up any brackets
     let clean_address = address.trim_start_matches('[').trim_end_matches(']');
-    HostPort {
+    Ok(HostPort {
         host: clean_address.to_string(),
         port: None,
-    }
+    })
 }
 
 #[cfg(test)]
@@ -1074,56 +1110,56 @@ mod tests {
 
     #[test]
     fn test_parse_host_port_hostname_only() {
-        let hp = parse_host_port("example.com");
+        let hp = parse_host_port("example.com").unwrap();
         assert_eq!(hp.host, "example.com");
         assert_eq!(hp.port, None);
     }
 
     #[test]
     fn test_parse_host_port_with_port() {
-        let hp = parse_host_port("example.com:8443");
+        let hp = parse_host_port("example.com:8443").unwrap();
         assert_eq!(hp.host, "example.com");
         assert_eq!(hp.port, Some(8443));
     }
 
     #[test]
     fn test_parse_host_port_https_url() {
-        let hp = parse_host_port("https://example.com:9443");
+        let hp = parse_host_port("https://example.com:9443").unwrap();
         assert_eq!(hp.host, "example.com");
         assert_eq!(hp.port, Some(9443));
     }
 
     #[test]
     fn test_parse_host_port_https_url_no_port() {
-        let hp = parse_host_port("https://example.com");
+        let hp = parse_host_port("https://example.com").unwrap();
         assert_eq!(hp.host, "example.com");
         assert_eq!(hp.port, None);
     }
 
     #[test]
     fn test_parse_host_port_http_url() {
-        let hp = parse_host_port("http://example.com:8080");
+        let hp = parse_host_port("http://example.com:8080").unwrap();
         assert_eq!(hp.host, "example.com");
         assert_eq!(hp.port, Some(8080));
     }
 
     #[test]
     fn test_parse_host_port_ipv4_with_port() {
-        let hp = parse_host_port("192.168.1.1:8443");
+        let hp = parse_host_port("192.168.1.1:8443").unwrap();
         assert_eq!(hp.host, "192.168.1.1");
         assert_eq!(hp.port, Some(8443));
     }
 
     #[test]
     fn test_parse_host_port_ipv4_no_port() {
-        let hp = parse_host_port("10.0.0.1");
+        let hp = parse_host_port("10.0.0.1").unwrap();
         assert_eq!(hp.host, "10.0.0.1");
         assert_eq!(hp.port, None);
     }
 
     #[test]
     fn test_parse_host_port_ipv6_with_port() {
-        let hp = parse_host_port("[::1]:443");
+        let hp = parse_host_port("[::1]:443").unwrap();
         // URL parser keeps brackets for IPv6 addresses
         assert_eq!(hp.host, "[::1]");
         // url.port() returns None for scheme-default ports (443 for HTTPS),
@@ -1133,27 +1169,27 @@ mod tests {
 
     #[test]
     fn test_parse_host_port_ipv6_with_non_default_port() {
-        let hp = parse_host_port("[::1]:8443");
+        let hp = parse_host_port("[::1]:8443").unwrap();
         assert_eq!(hp.host, "[::1]");
         assert_eq!(hp.port, Some(8443));
     }
 
     #[test]
     fn test_parse_host_port_ipv6_no_port() {
-        let hp = parse_host_port("[::1]");
+        let hp = parse_host_port("[::1]").unwrap();
         assert_eq!(hp.host, "[::1]");
         assert_eq!(hp.port, None);
     }
 
     #[test]
     fn test_parse_host_port_default_port_443() {
-        let hp = parse_host_port("example.com");
+        let hp = parse_host_port("example.com").unwrap();
         assert_eq!(hp.port, None); // None means default 443
     }
 
     #[test]
     fn test_parse_host_port_subdomain() {
-        let hp = parse_host_port("sub.domain.example.com:8443");
+        let hp = parse_host_port("sub.domain.example.com:8443").unwrap();
         assert_eq!(hp.host, "sub.domain.example.com");
         assert_eq!(hp.port, Some(8443));
     }
@@ -1204,6 +1240,23 @@ mod tests {
         let final_config = load_config(&cli).unwrap();
         assert!(final_config.check_revocation);
         assert!(final_config.grade);
+    }
+
+    #[test]
+    fn test_parse_host_port_invalid_port_is_error() {
+        let result = parse_host_port("example.com:99999");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid port '99999'"));
+    }
+
+    #[test]
+    fn test_parse_host_port_non_numeric_suffix_is_hostname() {
+        // A colon followed by non-digits is not a port specification; the
+        // address is treated as an (almost certainly unresolvable) hostname
+        // rather than rejected here.
+        let hp = parse_host_port("example.com:abc").unwrap();
+        assert_eq!(hp.host, "example.com:abc");
+        assert_eq!(hp.port, None);
     }
 
     // ── OutFormat Display tests ──────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,20 +379,17 @@ impl Formatter for TextFormat {
                 writeln!(output, "\tDNS Name: {}", san).unwrap();
             }
 
-            match &cert.chain {
-                Some(chains) => {
-                    writeln!(output, "Additional Certificates (if supplied):").unwrap();
-                    for (i, c) in chains.iter().enumerate() {
-                        writeln!(output, "Chain #{:?}", i + 1).unwrap();
-                        writeln!(output, "\tSubject: {:?}", c.subject).unwrap();
-                        writeln!(output, "\tValid from: {:?}", c.valid_from).unwrap();
-                        writeln!(output, "\tValid until: {:?}", c.valid_to).unwrap();
-                        writeln!(output, "\tIssuer: {:?}", c.issuer).unwrap();
-                        writeln!(output, "\tSignature algorithm: {:?}", c.signature_algorithm)
-                            .unwrap();
-                    }
+            if let Some(chains) = &cert.chain {
+                writeln!(output, "Additional Certificates (if supplied):").unwrap();
+                for (i, c) in chains.iter().enumerate() {
+                    writeln!(output, "Chain #{:?}", i + 1).unwrap();
+                    writeln!(output, "\tSubject: {:?}", c.subject).unwrap();
+                    writeln!(output, "\tValid from: {:?}", c.valid_from).unwrap();
+                    writeln!(output, "\tValid until: {:?}", c.valid_to).unwrap();
+                    writeln!(output, "\tIssuer: {:?}", c.issuer).unwrap();
+                    writeln!(output, "\tSignature algorithm: {:?}", c.signature_algorithm)
+                        .unwrap();
                 }
-                None => todo!(),
             }
         }
         output
@@ -1448,6 +1445,16 @@ mod tests {
             scan: None,
             ct: None,
         }
+    }
+
+    #[test]
+    fn test_text_format_without_chain_does_not_panic() {
+        // Regression: the `chain: None` arm used to be `todo!()`.
+        let mut tls = make_test_tls();
+        tls.certificate.chain = None;
+        let output = TextFormat.format(&[tls]);
+        assert!(output.contains("Hostname: test.example.com"));
+        assert!(!output.contains("Additional Certificates"));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,16 +58,16 @@ struct Args {
     ///
     /// Queries OCSP responders first, then falls back to CRL
     /// distribution points. Adds latency due to network requests.
-    #[arg(long, action = clap::ArgAction::SetTrue)]
-    check_revocation: Option<bool>,
+    #[arg(long)]
+    check_revocation: bool,
 
     /// Enable TLS configuration grading (A+ to F).
     ///
     /// Evaluates protocol version, cipher strength, key exchange,
     /// certificate key size, and trust chain to produce a composite
     /// letter grade for each host.
-    #[arg(long, action = clap::ArgAction::SetTrue)]
-    grade: Option<bool>,
+    #[arg(long)]
+    grade: bool,
 
     /// Minimum number of days a certificate must remain valid.
     ///
@@ -956,14 +956,17 @@ fn load_config(cli: &Args) -> Result<FinalConfig, ConfigError> {
         None
     };
 
+    // Boolean flags are only forwarded when actually passed on the command
+    // line: an absent flag must stay `None` so it does not override a value
+    // set in the config file during the "last `Some` wins" merge.
     let cli_config = Config::from_cli_args(
         cli_addresses,
         cli.output.as_ref().map(|o| o.to_string()),
         cli.exit_code,
         cli.prometheus,
         cli.prometheus_address.clone(),
-        cli.check_revocation,
-        cli.grade,
+        cli.check_revocation.then_some(true),
+        cli.grade.then_some(true),
         cli.min_validity,
     );
 
@@ -1156,6 +1159,54 @@ mod tests {
         let hp = parse_host_port("sub.domain.example.com:8443");
         assert_eq!(hp.host, "sub.domain.example.com");
         assert_eq!(hp.port, Some(8443));
+    }
+
+    // ── CLI flag / config precedence tests ───────────────────────────
+
+    #[test]
+    fn test_absent_bool_flags_do_not_override_config() {
+        use clap::Parser;
+        // Absent flags parse as plain `false`...
+        let cli = Args::try_parse_from(["tlschecker", "example.com"]).unwrap();
+        assert!(!cli.check_revocation);
+        assert!(!cli.grade);
+
+        // ...and a config file enabling them must survive a CLI run where the
+        // flags are absent (regression: Option<bool> + SetTrue used to yield
+        // Some(false), silently overriding the config file).
+        let mut config_file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(
+            &mut config_file,
+            b"hosts = [\"example.com\"]\ncheck_revocation = true\ngrade = true\n",
+        )
+        .unwrap();
+        let cli = Args::try_parse_from([
+            "tlschecker",
+            "--config",
+            config_file.path().to_str().unwrap(),
+        ])
+        .unwrap();
+        let final_config = load_config(&cli).unwrap();
+        assert!(final_config.check_revocation);
+        assert!(final_config.grade);
+    }
+
+    #[test]
+    fn test_present_bool_flags_override_config() {
+        use clap::Parser;
+        let mut config_file = tempfile::NamedTempFile::new().unwrap();
+        std::io::Write::write_all(&mut config_file, b"hosts = [\"example.com\"]\n").unwrap();
+        let cli = Args::try_parse_from([
+            "tlschecker",
+            "--config",
+            config_file.path().to_str().unwrap(),
+            "--check-revocation",
+            "--grade",
+        ])
+        .unwrap();
+        let final_config = load_config(&cli).unwrap();
+        assert!(final_config.check_revocation);
+        assert!(final_config.grade);
     }
 
     // ── OutFormat Display tests ──────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
 use std::thread;
 mod config;
 mod metrics;
@@ -717,6 +719,97 @@ impl FinalConfig {
     }
 }
 
+/// Upper bound on concurrent host checks; the pool also never exceeds the
+/// machine's available parallelism or the number of hosts.
+const MAX_CONCURRENT_CHECKS: usize = 16;
+
+/// Checks a single host: TLS connection plus the optional scan and CT lookup.
+///
+/// Returns `None` when the host could not be checked at all; the reason is
+/// logged to stderr before returning.
+fn check_host(
+    host_port: &HostPort,
+    check_revocation: bool,
+    calculate_grade: bool,
+    do_scan: bool,
+    do_ct: bool,
+) -> Option<TLS> {
+    let port_display = host_port.port.map_or(String::new(), |p| format!(":{}", p));
+
+    match TLS::from(
+        &host_port.host,
+        host_port.port,
+        check_revocation,
+        calculate_grade,
+    ) {
+        Ok(mut cert) => {
+            if do_scan {
+                if let Ok(scan) = tlschecker::probe::scan_tls(&host_port.host, host_port.port) {
+                    // Fold scan-derived warnings into the result and
+                    // recompute the grade to reflect full posture.
+                    cert.apply_scan(scan);
+                }
+            }
+            if do_ct {
+                // Look the leaf up in public CT logs (crt.sh, by
+                // SHA-256 fingerprint). A failed/inconclusive lookup
+                // is non-fatal: the reason is logged to stderr and the
+                // result is recorded as `Unknown` rather than dropped,
+                // so "could not check" is never mistaken for "absent".
+                let ct = match tlschecker::ct::check_ct_status(&cert.certificate.cert_sha256) {
+                    Ok(ct) => ct,
+                    Err(e) => {
+                        warn!(
+                            "CT lookup could not be completed for {}{}: {}",
+                            host_port.host, port_display, e
+                        );
+                        tlschecker::ct::CtStatus::Unknown
+                    }
+                };
+                cert.apply_ct(ct);
+            }
+            Some(cert)
+        }
+        Err(err) => {
+            match err {
+                TLSError::DNS(msg) => {
+                    error!(
+                        "Cannot resolve hostname: {}{}",
+                        host_port.host, port_display
+                    );
+                    error!("  - {}", msg);
+                }
+                TLSError::Connection(e) => {
+                    error!(
+                        "Connection refused for host: {}{}",
+                        host_port.host, port_display
+                    );
+                    error!("  - {}", e);
+                }
+                TLSError::Certificate(msg) => {
+                    error!(
+                        "Certificate issue with host: {}{}",
+                        host_port.host, port_display
+                    );
+                    error!("  - {}", msg);
+                }
+                TLSError::Validation(msg) => {
+                    error!(
+                        "Validation error for host: {}{}",
+                        host_port.host, port_display
+                    );
+                    error!("  - {}", msg);
+                }
+                _ => {
+                    error!("Failed to check host: {}{}", host_port.host, port_display);
+                    error!("  - {}", err);
+                }
+            }
+            None
+        }
+    }
+}
+
 fn main() -> Result<()> {
     // Initialize tracing. Diagnostics (errors, warnings) go to stderr so stdout
     // stays a clean machine-readable stream — e.g. `-o json ... | jq` is not
@@ -774,122 +867,71 @@ fn main() -> Result<()> {
     // scanned posture, so enable grading whenever scanning.
     let calculate_grade = should_grade(final_config.grade, do_scan);
 
-    let mut handles = Vec::new();
+    // Check hosts through a bounded worker pool rather than one thread per
+    // host: a large host list would otherwise spawn an unbounded number of
+    // threads, each potentially holding a 30s connection timeout.
+    let worker_count = std::thread::available_parallelism()
+        .map(|n| n.get())
+        .unwrap_or(4)
+        .min(MAX_CONCURRENT_CHECKS)
+        .min(hosts_len.max(1));
 
-    for host_port in hosts_and_ports {
-        let handle = thread::spawn(move || {
-            let port_display = host_port.port.map_or(String::new(), |p| format!(":{}", p));
+    let queue: Arc<Mutex<VecDeque<(usize, HostPort)>>> =
+        Arc::new(Mutex::new(hosts_and_ports.into_iter().enumerate().collect()));
 
-            match TLS::from(
-                &host_port.host,
-                host_port.port,
-                check_revocation,
-                calculate_grade,
-            ) {
-                Ok(mut cert) => {
-                    if do_scan {
-                        if let Ok(scan) =
-                            tlschecker::probe::scan_tls(&host_port.host, host_port.port)
-                        {
-                            // Fold scan-derived warnings into the result and
-                            // recompute the grade to reflect full posture.
-                            cert.apply_scan(scan);
-                        }
-                    }
-                    if do_ct {
-                        // Look the leaf up in public CT logs (crt.sh, by
-                        // SHA-256 fingerprint). A failed/inconclusive lookup
-                        // is non-fatal: the reason is logged to stderr and the
-                        // result is recorded as `Unknown` rather than dropped,
-                        // so "could not check" is never mistaken for "absent".
-                        let ct =
-                            match tlschecker::ct::check_ct_status(&cert.certificate.cert_sha256) {
-                                Ok(ct) => ct,
-                                Err(e) => {
-                                    warn!(
-                                        "CT lookup could not be completed for {}{}: {}",
-                                        host_port.host, port_display, e
-                                    );
-                                    tlschecker::ct::CtStatus::Unknown
-                                }
-                            };
-                        cert.apply_ct(ct);
-                    }
-                    Some(cert)
-                }
-                Err(err) => {
-                    match err {
-                        TLSError::DNS(msg) => {
-                            error!(
-                                "Cannot resolve hostname: {}{}",
-                                host_port.host, port_display
-                            );
-                            error!("  - {}", msg);
-                        }
-                        TLSError::Connection(e) => {
-                            error!(
-                                "Connection refused for host: {}{}",
-                                host_port.host, port_display
-                            );
-                            error!("  - {}", e);
-                        }
-                        TLSError::Certificate(msg) => {
-                            error!(
-                                "Certificate issue with host: {}{}",
-                                host_port.host, port_display
-                            );
-                            error!("  - {}", msg);
-                        }
-                        TLSError::Validation(msg) => {
-                            error!(
-                                "Validation error for host: {}{}",
-                                host_port.host, port_display
-                            );
-                            error!("  - {}", msg);
-                        }
-                        _ => {
-                            error!("Failed to check host: {}{}", host_port.host, port_display);
-                            error!("  - {}", err);
-                        }
-                    }
-                    None
-                }
+    let mut handles = Vec::with_capacity(worker_count);
+    for _ in 0..worker_count {
+        let queue = Arc::clone(&queue);
+        handles.push(thread::spawn(move || {
+            let mut outcomes = Vec::new();
+            loop {
+                let job = queue.lock().unwrap().pop_front();
+                let Some((index, host_port)) = job else { break };
+                outcomes.push((
+                    index,
+                    check_host(&host_port, check_revocation, calculate_grade, do_scan, do_ct),
+                ));
             }
-        });
-        handles.push(handle);
+            outcomes
+        }));
     }
 
-    let mut results: Vec<TLS> = Vec::with_capacity(hosts_len);
-
+    // Collect into index-order slots so the output order matches the input
+    // order regardless of which worker handled which host.
+    let mut slots: Vec<Option<Option<TLS>>> = std::iter::repeat_with(|| None)
+        .take(hosts_len)
+        .collect();
     for handle in handles {
         match handle.join() {
-            Ok(Some(tls_result)) => results.push(tls_result),
-            Ok(None) => error_count += 1, // Error already logged inside the thread
+            Ok(outcomes) => {
+                for (index, outcome) in outcomes {
+                    slots[index] = Some(outcome);
+                }
+            }
             Err(panic_err) => {
                 error!("A worker thread panicked unexpectedly: {:?}", panic_err);
-                error_count += 1;
             }
         }
     }
 
-    let expired_certs = &results
-        .clone()
-        .into_iter()
-        .filter(|c| c.certificate.is_expired)
-        .collect::<Vec<_>>();
+    let mut results: Vec<TLS> = Vec::with_capacity(hosts_len);
+    for slot in slots {
+        match slot {
+            Some(Some(tls_result)) => results.push(tls_result),
+            // Error already logged inside the worker, or the host was lost to
+            // a worker panic.
+            Some(None) | None => error_count += 1,
+        }
+    }
 
-    let revoked_certs = &results
-        .clone()
-        .into_iter()
-        .filter(|c| {
-            matches!(
-                c.certificate.revocation_status,
-                RevocationStatus::Revoked(_)
-            )
-        })
-        .collect::<Vec<_>>();
-
-    if !expired_certs.is_empty() || !revoked_certs.is_empty() {
+    let any_expired = results.iter().any(|c| c.certificate.is_expired);
+    let any_revoked = results.iter().any(|c| {
+        matches!(
+            c.certificate.revocation_status,
+            RevocationStatus::Revoked(_)
+        )
+    });
+    if any_expired || any_revoked {
         failed_result = true;
     }
 
@@ -915,11 +957,7 @@ fn main() -> Result<()> {
             print!("{}", r.certificate.pem);
         }
     } else {
-        let formatter = match final_config.output {
-            OutFormat::Json => FormatterFactory::new_formatter(&OutFormat::Json),
-            OutFormat::Text => FormatterFactory::new_formatter(&OutFormat::Text),
-            OutFormat::Summary => FormatterFactory::new_formatter(&OutFormat::Summary),
-        };
+        let formatter = FormatterFactory::new_formatter(&final_config.output);
         print!("{}", formatter.format(&results));
     }
 

--- a/src/metrics/prom.rs
+++ b/src/metrics/prom.rs
@@ -8,6 +8,7 @@
 //! - `tlschecker_days_before_expired` - Days until certificate expiration (gauge)
 //! - `tlschecker_hours_before_expired` - Hours until certificate expiration (gauge)
 //! - `tlschecker_revocation_status` - Certificate revocation status (gauge)
+//! - `tlschecker_grade_score` - TLS configuration grade score, only when grading ran (gauge)
 //! - `tlschecker_below_min_validity` - Whether certificate is below minimum validity threshold (gauge)
 //!
 //! # Metric Labels
@@ -29,43 +30,76 @@
 //! - `2.0` - Unknown (couldn't determine)
 //! - `3.0` - Revoked
 
-use lazy_static::lazy_static;
-use prometheus::{labels, register_gauge, Gauge};
+use prometheus::proto::MetricFamily;
+use prometheus::{labels, Gauge, Registry};
 
 use tlschecker::RevocationStatus;
 use tlschecker::TLS;
 
-lazy_static! {
-    /// Gauge metric tracking days until certificate expiration.
-    static ref TLSCHECKER_DAYS_BEFORE_EXPIRED: Gauge =
-        register_gauge!("tlschecker_days_before_expired", "days before expiration").unwrap();
+/// Builds the metric families for a single host's check result.
+///
+/// Each host gets a **fresh registry** so values never leak between hosts:
+/// with shared global gauges, a host without a grade would push the previous
+/// host's `tlschecker_grade_score` under its own labels. The grade gauge is
+/// only registered when grading was actually performed for this host.
+fn host_metric_families(tls: &TLS, min_validity: i32) -> Vec<MetricFamily> {
+    let registry = Registry::new();
 
-    /// Gauge metric tracking hours until certificate expiration.
-    static ref TLSCHECKER_HOURS_BEFORE_EXPIRED: Gauge =
-        register_gauge!("tlschecker_hours_before_expired", "hours before expiration").unwrap();
+    let register_gauge = |name: &str, help: &str, value: f64| {
+        match Gauge::new(name, help) {
+            Ok(gauge) => {
+                gauge.set(value);
+                if let Err(e) = registry.register(Box::new(gauge)) {
+                    eprintln!("Failed to register metric {}: {}", name, e);
+                }
+            }
+            Err(e) => eprintln!("Failed to create metric {}: {}", name, e),
+        };
+    };
 
-    /// Gauge metric tracking certificate revocation status.
-    /// Values: 0=not checked, 1=good, 2=unknown, 3=revoked
-    static ref TLSCHECKER_REVOCATION_STATUS: Gauge = register_gauge!(
+    register_gauge(
+        "tlschecker_days_before_expired",
+        "days before expiration",
+        f64::from(tls.certificate.validity_days),
+    );
+    register_gauge(
+        "tlschecker_hours_before_expired",
+        "hours before expiration",
+        f64::from(tls.certificate.validity_hours),
+    );
+
+    // 0 = Not checked, 1 = Good, 2 = Unknown, 3 = Revoked
+    let revocation_value = match tls.certificate.revocation_status {
+        RevocationStatus::NotChecked => 0.0,
+        RevocationStatus::Good => 1.0,
+        RevocationStatus::Unknown => 2.0,
+        RevocationStatus::Revoked(_) => 3.0,
+    };
+    register_gauge(
         "tlschecker_revocation_status",
-        "certificate revocation status"
-    )
-    .unwrap();
+        "certificate revocation status",
+        revocation_value,
+    );
 
-    /// Gauge metric tracking TLS configuration grade score (0-100).
-    static ref TLSCHECKER_GRADE_SCORE: Gauge = register_gauge!(
-        "tlschecker_grade_score",
-        "TLS configuration grade score (0-100)"
-    )
-    .unwrap();
+    // Only exported when grading was performed for this host.
+    if let Some(ref grade) = tls.grade {
+        register_gauge(
+            "tlschecker_grade_score",
+            "TLS configuration grade score (0-100)",
+            f64::from(grade.score),
+        );
+    }
 
-    /// Gauge metric indicating if certificate validity is below the configured minimum threshold.
-    /// Values: 0=above threshold or not configured, 1=below threshold
-    static ref TLSCHECKER_BELOW_MIN_VALIDITY: Gauge = register_gauge!(
+    let below_min_validity = min_validity > 0
+        && !tls.certificate.is_expired
+        && tls.certificate.validity_days < min_validity;
+    register_gauge(
         "tlschecker_below_min_validity",
-        "1 if certificate validity is below the configured minimum threshold, 0 otherwise"
-    )
-    .unwrap();
+        "1 if certificate validity is below the configured minimum threshold, 0 otherwise",
+        if below_min_validity { 1.0 } else { 0.0 },
+    );
+
+    registry.gather()
 }
 
 /// Pushes TLS certificate metrics to a Prometheus Push Gateway.
@@ -84,6 +118,7 @@ lazy_static! {
 /// For each certificate:
 /// - Days and hours until expiration
 /// - Revocation status (0-3, see module documentation)
+/// - Grade score (only when grading was performed)
 /// - Associated labels (host, cipher, issuer, etc.)
 ///
 /// # Error Handling
@@ -102,35 +137,11 @@ lazy_static! {
 /// ```
 pub fn prometheus_metrics(results: Vec<TLS>, prometheus_address: String, min_validity: i32) {
     for tls in results.iter() {
-        TLSCHECKER_DAYS_BEFORE_EXPIRED.set(f64::from(tls.certificate.validity_days.to_owned()));
-        TLSCHECKER_HOURS_BEFORE_EXPIRED.set(f64::from(tls.certificate.validity_hours.to_owned()));
-
-        // Set revocation status metric
-        // 0 = Not checked, 1 = Good, 2 = Unknown, 3 = Revoked
-        let revocation_value = match tls.certificate.revocation_status {
-            RevocationStatus::NotChecked => 0.0,
-            RevocationStatus::Good => 1.0,
-            RevocationStatus::Unknown => 2.0,
-            RevocationStatus::Revoked(_) => 3.0,
-        };
-        TLSCHECKER_REVOCATION_STATUS.set(revocation_value);
-
-        // Set grade score metric if grading was performed
-        if let Some(ref grade) = tls.grade {
-            TLSCHECKER_GRADE_SCORE.set(f64::from(grade.score));
-        }
-
-        // Set below minimum validity threshold metric
-        if min_validity > 0
+        let metric_families = host_metric_families(tls, min_validity);
+        let below_min_validity = min_validity > 0
             && !tls.certificate.is_expired
-            && tls.certificate.validity_days < min_validity
-        {
-            TLSCHECKER_BELOW_MIN_VALIDITY.set(1.0);
-        } else {
-            TLSCHECKER_BELOW_MIN_VALIDITY.set(0.0);
-        }
+            && tls.certificate.validity_days < min_validity;
 
-        let metric_families = prometheus::gather();
         let prometheus_client = prometheus::push_metrics(
             "tlschecker",
             labels! {
@@ -143,16 +154,122 @@ pub fn prometheus_metrics(results: Vec<TLS>, prometheus_address: String, min_val
                 "expired".to_owned() => tls.certificate.is_expired.to_string(),
                 "revoked".to_owned() => (matches!(tls.certificate.revocation_status, RevocationStatus::Revoked(_))).to_string(),
                 "grade".to_owned() => tls.grade.as_ref().map_or("N/A".to_string(), |g| g.grade.clone()),
-                "below_min_validity".to_owned() => (min_validity > 0 && !tls.certificate.is_expired && tls.certificate.validity_days < min_validity).to_string(),
+                "below_min_validity".to_owned() => below_min_validity.to_string(),
             },
             &format!("{}/metrics/job", prometheus_address),
             metric_families,
             None,
         );
 
-        match prometheus_client {
-            Ok(_) => {} //TODO
-            Err(e) => println!("\nFailed to push metrics to prometheus: {}", e),
+        if let Err(e) = prometheus_client {
+            eprintln!("\nFailed to push metrics to prometheus: {}", e);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tlschecker::{CertificateInfo, Cipher, Issuer, Subject};
+
+    fn make_test_tls() -> TLS {
+        TLS {
+            cipher: Cipher {
+                name: "TLS_AES_256_GCM_SHA384".to_string(),
+                version: "TLSv1.3".to_string(),
+                bits: 256,
+            },
+            certificate: CertificateInfo {
+                hostname: "test.example.com".to_string(),
+                subject: Subject {
+                    country_or_region: "US".to_string(),
+                    state_or_province: "None".to_string(),
+                    locality: "None".to_string(),
+                    organization_unit: "None".to_string(),
+                    organization: "Example Inc".to_string(),
+                    common_name: "test.example.com".to_string(),
+                },
+                issued: Issuer {
+                    country_or_region: "US".to_string(),
+                    organization: "Test CA".to_string(),
+                    common_name: "Test CA Root".to_string(),
+                },
+                valid_from: "Jan  1 00:00:00 2025 GMT".to_string(),
+                valid_to: "Dec 31 23:59:59 2026 GMT".to_string(),
+                validity_days: 100,
+                validity_hours: 2400,
+                is_expired: false,
+                cert_sn: "1".to_string(),
+                cert_ver: "2".to_string(),
+                cert_alg: "sha256WithRSAEncryption".to_string(),
+                sans: vec![],
+                chain: None,
+                revocation_status: RevocationStatus::NotChecked,
+                is_self_signed: false,
+                security_warnings: vec![],
+                cert_key_bits: 2048,
+                cert_key_algorithm: "RSA".to_string(),
+                cert_sha256: String::new(),
+                cert_sha1: String::new(),
+                scts: Vec::new(),
+                pem: String::new(),
+            },
+            grade: None,
+            scan: None,
+            ct: None,
+        }
+    }
+
+    fn family_names(families: &[MetricFamily]) -> Vec<&str> {
+        families.iter().map(|f| f.name()).collect()
+    }
+
+    #[test]
+    fn test_no_grade_gauge_without_grade() {
+        // Regression: with shared global gauges, a grade-less host pushed the
+        // previous host's grade score under its own labels.
+        let tls = make_test_tls();
+        let families = host_metric_families(&tls, 0);
+        let names = family_names(&families);
+        assert!(!names.contains(&"tlschecker_grade_score"));
+        assert!(names.contains(&"tlschecker_days_before_expired"));
+        assert!(names.contains(&"tlschecker_revocation_status"));
+    }
+
+    #[test]
+    fn test_grade_gauge_present_with_grade() {
+        let mut tls = make_test_tls();
+        tls.grade = Some(tlschecker::grading::TLSGrade {
+            grade: "A".to_string(),
+            score: 90,
+            categories: vec![],
+        });
+        let families = host_metric_families(&tls, 0);
+        let names = family_names(&families);
+        assert!(names.contains(&"tlschecker_grade_score"));
+
+        let grade_family = families
+            .iter()
+            .find(|f| f.name() == "tlschecker_grade_score")
+            .unwrap();
+        let value = grade_family.get_metric()[0].get_gauge().value();
+        assert_eq!(value, 90.0);
+    }
+
+    #[test]
+    fn test_below_min_validity_gauge() {
+        let tls = make_test_tls(); // 100 days left
+        let get_value = |min_validity: i32| {
+            host_metric_families(&tls, min_validity)
+                .iter()
+                .find(|f| f.name() == "tlschecker_below_min_validity")
+                .unwrap()
+                .get_metric()[0]
+                .get_gauge()
+                .value()
+        };
+        assert_eq!(get_value(0), 0.0); // disabled
+        assert_eq!(get_value(30), 0.0); // above threshold
+        assert_eq!(get_value(365), 1.0); // below threshold
     }
 }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -206,8 +206,10 @@ fn try_handshake(
 /// resolve.
 #[instrument]
 pub fn scan_tls(host: &str, port: Option<u16>) -> Result<TlsScan, TLSError> {
-    // Strip IPv6 brackets so "[::1]" resolves like the bare "::1".
-    let host = crate::unbracket_host(host.trim());
+    // Strip IPv6 brackets so "[::1]" resolves like the bare "::1", and
+    // convert IDN hostnames to their ASCII form for resolution.
+    let host = crate::to_ascii_hostname(crate::unbracket_host(host.trim()));
+    let host = host.as_str();
     if host.is_empty() {
         return Err(TLSError::Validation("Hostname cannot be empty".to_string()));
     }

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -157,7 +157,7 @@ pub struct ProtocolSupport {
 /// cipher could not be set or the handshake failed for any reason.
 fn try_handshake(
     host: &str,
-    port: u16,
+    addr: std::net::SocketAddr,
     version: SslVersion,
     cipher_list: Option<&str>,
     ciphersuites: Option<&str>,
@@ -180,9 +180,6 @@ fn try_handshake(
     let mut ssl = Ssl::new(&ctx).ok()?;
     ssl.set_hostname(host).ok()?;
 
-    // Use the (host, port) tuple rather than "{host}:{port}" so IPv6 literals
-    // (e.g. "::1") resolve correctly without needing bracket syntax.
-    let addr = (host, port).to_socket_addrs().ok()?.next()?;
     let tcp = TcpStream::connect_timeout(&addr, PROBE_TIMEOUT).ok()?;
     tcp.set_read_timeout(Some(PROBE_TIMEOUT)).ok()?;
     tcp.set_write_timeout(Some(PROBE_TIMEOUT)).ok()?;
@@ -204,8 +201,9 @@ fn try_handshake(
 ///
 /// # Returns
 ///
-/// A [`TlsScan`] describing per-version support, or [`TLSError::Validation`]
-/// if the hostname is empty.
+/// A [`TlsScan`] describing per-version support, [`TLSError::Validation`] if
+/// the hostname is empty, or a connection/DNS error when the host does not
+/// resolve.
 #[instrument]
 pub fn scan_tls(host: &str, port: Option<u16>) -> Result<TlsScan, TLSError> {
     // Strip IPv6 brackets so "[::1]" resolves like the bare "::1".
@@ -215,16 +213,26 @@ pub fn scan_tls(host: &str, port: Option<u16>) -> Result<TlsScan, TLSError> {
     }
     let port = port.unwrap_or(443);
 
+    // Resolve once up front: a scan performs on the order of a hundred
+    // handshake attempts, and per-attempt resolution would both hammer the
+    // resolver and risk probing different IPs of a multi-address host,
+    // making per-version results incoherent.
+    let addr = (host, port)
+        .to_socket_addrs()
+        .map_err(TLSError::Connection)?
+        .next()
+        .ok_or_else(|| TLSError::DNS("Failed parse remote hostname".to_string()))?;
+
     let mut protocols = Vec::with_capacity(VERSIONS.len());
     for &(ssl_version, version) in VERSIONS {
         // Is this version accepted at all (with a default cipher selection)?
-        let supported = try_handshake(host, port, ssl_version, None, None).is_some();
+        let supported = try_handshake(host, addr, ssl_version, None, None).is_some();
 
         let mut ciphers = Vec::new();
         if supported {
             if ssl_version == SslVersion::TLS1_3 {
                 for suite in TLS13_CIPHERS {
-                    if let Some(name) = try_handshake(host, port, ssl_version, None, Some(suite)) {
+                    if let Some(name) = try_handshake(host, addr, ssl_version, None, Some(suite)) {
                         if !ciphers.contains(&name) {
                             ciphers.push(name);
                         }
@@ -232,7 +240,7 @@ pub fn scan_tls(host: &str, port: Option<u16>) -> Result<TlsScan, TLSError> {
                 }
             } else {
                 for cipher in LEGACY_CIPHERS {
-                    if let Some(name) = try_handshake(host, port, ssl_version, Some(cipher), None) {
+                    if let Some(name) = try_handshake(host, addr, ssl_version, Some(cipher), None) {
                         if !ciphers.contains(&name) {
                             ciphers.push(name);
                         }

--- a/src/sct.rs
+++ b/src/sct.rs
@@ -17,8 +17,6 @@
 //! TLS-serialized SCT list by hand. It is **best-effort and never fails the
 //! caller** — any malformed or absent structure yields an empty list.
 
-use std::convert::TryInto;
-
 use openssl::x509::X509Ref;
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
## Summary

A code audit of the repo found seven confirmed bugs and a set of smaller cleanups; this PR fixes all of them. One commit per issue group, each with offline tests following the repo's synthetic-cert test convention.

## Bug fixes

- **Config-file `check_revocation`/`grade` were silently ignored.** `Option<bool>` + `ArgAction::SetTrue` yields `Some(false)` for an *absent* flag, which overrode config-file `true` values in the last-`Some`-wins merge. Flags are now plain `bool` and only forwarded when passed. Regression-tested with a temp config file.
- **`validity_hours` was `days * 24`.** A cert expiring in 10 hours reported 0 days *and* 0 hours. Hours now include the sub-day remainder (also feeds the Prometheus hours gauge).
- **Stale CRLs were trusted.** A correctly-signed CRL with `nextUpdate` in the past may predate a revocation (e.g. a replayed old CRL); it is now rejected and revocation degrades to `Unknown`, mirroring the OCSP verification-failure handling. Tested offline with builder-generated CRLs.
- **Panic paths on odd/hostile certs**: `todo!()` in the text formatter when a `TLS` has no chain, `.expect()` on non-UTF-8 name entries, `.unwrap()` on serial numbers, and `.unwrap()` on the CRL issuer's public key — all degrade gracefully now.
- **Prometheus pushed stale grades across hosts.** The module-global grade gauge was only set when a grade existed, so a grade-less host pushed the previous host's score under its own labels. Each host now gathers from a fresh `Registry`; `lazy_static` dropped.
- **Unreachable hosts never failed the exit code.** New opt-in `--fail-on-error` flag counts hosts that couldn't be checked at all (DNS/connect/handshake/invalid address) as failures for `--exit-code`; default behavior unchanged.
- **`example.com:99999` was treated as a hostname.** An address with an out-of-range numeric port is now reported as an invalid port instead of surfacing later as a confusing DNS error.

## Cleanups

- Bounded worker pool (min of CPU parallelism, 16, host count) instead of one unbounded thread per host; output order still matches input order
- `scan_tls` resolves DNS once instead of per handshake attempt (~100+ lookups per scanned host, and probes could flap between IPs of a multi-address host)
- IDN hostnames (`bücher.example`) are converted to A-label form before SAN matching and resolution, via `idna` (already in the tree through `url`)
- `license = "GNU"` → `GPL-3.0-only` (valid SPDX, matches the LICENSE file), edition 2018 → 2021, removed double `results.clone()`, collapsed redundant formatter match, synced the README's outdated config-file example with `Config::example_toml()`

## Verification

- `cargo clippy` clean, all offline tests pass (~15 new tests added), doc-tests pass
- Network suite (`cargo test -- --ignored`) passes; the crt.sh live test is rate-limit flaky when the whole suite runs at once and passes on rerun (pre-existing)
- Manual: summary/text/JSON output against example.com (hours column now shows e.g. 1222 instead of 1200), config-file revocation takes effect without the CLI flag, `--fail-on-error` exit codes verified, `--scan` completes and grades

## Notes for review

- The "CRL without `nextUpdate`" branch (accept + warn, per RFC 5280 optionality) has no builder-based test because openssl's `X509CrlBuilder` refuses to build a CRL without one.
- `--fail-on-error` follows the existing convention of pure CLI flags (`--scan`, `--ct-check`) and is deliberately not part of the config file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)