### PR TITLE
chore: release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2026-07-20
+
+A maintenance release focused on Prometheus/observability robustness and the
+example deployment assets. No library or CLI behavior changes beyond the
+Prometheus push path.
+
+### Fixed
+
+- **Prometheus push grouping key is now stable identity only** (`job` +
+  `instance`). Volatile metadata (grade, cipher, protocol version, issuer) moved
+  onto a dedicated `tlschecker_certificate_info` info metric so changing values
+  no longer orphan a previous run's series in the push gateway.
+- `--prometheus` is now a plain boolean flag rather than taking an optional
+  value.
+
+### Added
+
+- **Grafana dashboard** and **Prometheus alert rules** examples, hardened for
+  SRE use, plus a **Kubernetes CronJob** example manifest.
+
+### Changed
+
+- Grafana dashboard: "Days until expiration" is shown in days (not auto-scaled
+  units) and the cert-health stat tiles are scoped to the `Issuer` variable.
+- CI: bumped `actions/checkout` to v7.
+
 ## [2.0.0] - 2026-07-20
 
 A large feature release that turns `tlschecker` from a batch certificate checker
@@ -66,5 +92,6 @@ scanning, and Certificate Transparency support.
 
 See the Git history for changes in 1.1.1 and earlier.
 
+[2.0.1]: https://github.com/jbovet/tlschecker/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/jbovet/tlschecker/compare/v1.1.1...v2.0.0
 [1.1.1]: https://github.com/jbovet/tlschecker/releases/tag/v1.1.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2741,7 +2741,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tlschecker"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tlschecker"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.88.0"                                                    # MSRV (required by ratatui 0.30)
 description = "Experimental TLS/SSL certificate checker from command line"

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The TUI is only used when stdout is an interactive terminal. In non-interactive 
 If you are utilizing M1 or higher, please add the option --platform linux/x86_64.
 
 ```sh
-docker run --platform linux/x86_64 josebovet/tlschecker:2.0.0 jpbd.dev
+docker run --platform linux/x86_64 josebovet/tlschecker:2.0.1 jpbd.dev
 ```
 
 ## Install
@@ -39,7 +39,7 @@ docker run --platform linux/x86_64 josebovet/tlschecker:2.0.0 jpbd.dev
 Linux
 
 ```sh
-curl -LO https://github.com/jbovet/tlschecker/releases/download/v2.0.0/tlschecker-linux.zip
+curl -LO https://github.com/jbovet/tlschecker/releases/download/v2.0.1/tlschecker-linux.zip
 unzip tlschecker-linux.zip
 chmod 755 tlschecker
 sudo install tlschecker /usr/local/bin/tlschecker
@@ -48,7 +48,7 @@ sudo install tlschecker /usr/local/bin/tlschecker
 Osx
 
 ```sh
-curl -LO https://github.com/jbovet/tlschecker/releases/download/v2.0.0/tlschecker-macos.zip
+curl -LO https://github.com/jbovet/tlschecker/releases/download/v2.0.1/tlschecker-macos.zip
 unzip tlschecker-macos.zip
 chmod 755 tlschecker
 sudo install tlschecker /usr/local/bin/tlschecker


### PR DESCRIPTION
## Summary

Prepares the **2.0.1** patch release, capturing the post-2.0.0 changes to the Prometheus/observability path and example deployment assets.

- Bump version `2.0.0` → `2.0.1` in `Cargo.toml` and `Cargo.lock`
- Update Docker tag and Linux/macOS download URLs in `README.md` → `v2.0.1`
- Add a `[2.0.1]` section to `CHANGELOG.md` with a compare link

## Release notes (2.0.1)

**Fixed**
- Prometheus push grouping key is now stable identity only (`job` + `instance`); volatile metadata (grade, cipher, protocol version, issuer) moved onto the dedicated `tlschecker_certificate_info` info metric so changing values no longer orphan a previous run's series in the push gateway.
- `--prometheus` is now a plain boolean flag rather than taking an optional value.

**Added**
- Grafana dashboard and Prometheus alert-rules examples, plus a Kubernetes CronJob example manifest.

**Changed**
- Grafana dashboard: "Days until expiration" shown in days (not auto-scaled), cert-health stat tiles scoped to the `Issuer` variable.
- CI: bumped `actions/checkout` to v7.

## Notes

- Two of the underlying commits are `feat(...)` (Grafana dashboard, alert rules), but they are additive example/deployment assets with no library or CLI API change, so a **patch** bump is appropriate.
- There are no existing git tags in the repo (2.0.0 shipped as a commit). The `v2.0.1` tag can be created once this merges.

## Verification

- `cargo build` succeeds, compiling `tlschecker v2.0.1` (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123tudF1oyZPx2gwhLn2Rwn

---
_Generated by [Claude Code](https://claude.ai/code/session_0123tudF1oyZPx2gwhLn2Rwn)_