### PR TITLE
test(config): guard example_toml() against schema drift; add integrat…

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,49 @@
+name: Integration & Coverage
+
+# Network integration tests hit real external hosts (google.com, *.badssl.com,
+# digicert.com), so they are kept OFF the pull-request path — a flaky responder
+# must never block a merge. They run on a weekly schedule and on demand.
+# Coverage measures the offline suite (deterministic) on push/PR.
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+  schedule:
+    - cron: '0 6 * * 1'   # Mondays 06:00 UTC
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # The 21 `#[ignore]` tests that connect to live TLS/OCSP/CRL/CT endpoints.
+  # Only runs on the schedule or a manual dispatch, never on PRs.
+  network-tests:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Run ignored (network) tests
+        run: cargo test --verbose -- --ignored
+
+  # Line coverage of the offline test suite, uploaded as an artifact and
+  # summarized in the job log. No external coverage service required.
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: llvm-tools-preview
+      - uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate coverage (offline tests)
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+      - name: Coverage summary
+        run: cargo llvm-cov report --summary-only >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload lcov report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-lcov
+          path: lcov.info
+          if-no-files-found: error

--- a/src/config.rs
+++ b/src/config.rs
@@ -623,4 +623,62 @@ mod tests {
         let parsed: Config = toml::from_str(&example).unwrap();
         assert_eq!(parsed.min_validity, Some(30));
     }
+
+    /// Collect every leaf key-path (e.g. `prometheus.address`) from a TOML
+    /// document, so two schemas can be compared by the options they expose.
+    fn toml_key_paths(doc: &str) -> std::collections::BTreeSet<String> {
+        fn walk(value: &toml::Value, prefix: &str, out: &mut std::collections::BTreeSet<String>) {
+            if let toml::Value::Table(table) = value {
+                for (key, child) in table {
+                    let path = if prefix.is_empty() {
+                        key.clone()
+                    } else {
+                        format!("{prefix}.{key}")
+                    };
+                    out.insert(path.clone());
+                    walk(child, &path, out);
+                }
+            }
+        }
+
+        let mut out = std::collections::BTreeSet::new();
+        let value: toml::Value = toml::from_str(doc).expect("valid TOML");
+        walk(&value, "", &mut out);
+        out
+    }
+
+    /// Guards the "keep the canonical example in sync with the schema" contract
+    /// noted in CLAUDE.md. `example_toml()` builds a full `Config` struct literal,
+    /// so the compiler already forces every field to be *listed* — but a future
+    /// `Option` field set to `None` would compile fine yet silently drop out of
+    /// the generated TOML (and thus out of `--generate-config`). This asserts the
+    /// example demonstrates every option the schema can express.
+    #[test]
+    fn test_example_toml_documents_every_config_field() {
+        // A fully-populated Config. Adding a field to `Config`/`PrometheusConfig`
+        // forces a value here (struct literals require every field), so this
+        // reference can't silently fall behind the schema.
+        let fully_populated = Config {
+            hosts: Some(vec!["example.com".to_string()]),
+            output: Some("summary".to_string()),
+            exit_code: Some(1),
+            check_revocation: Some(true),
+            prometheus: Some(PrometheusConfig {
+                enabled: Some(true),
+                address: Some("http://localhost:9091".to_string()),
+            }),
+            grade: Some(true),
+            min_validity: Some(30),
+        };
+
+        let expected = toml_key_paths(&toml::to_string(&fully_populated).unwrap());
+        let example = toml_key_paths(&Config::example_toml());
+
+        let missing: Vec<&String> = expected.difference(&example).collect();
+        assert!(
+            missing.is_empty(),
+            "Config::example_toml() omits config keys {missing:?}; every option must \
+             appear so `--generate-config` never ships an incomplete template."
+        );
+    }
 }


### PR DESCRIPTION
…ion+coverage CI

- Add a forget-proof test asserting Config::example_toml() emits every schema key: a future Option field set to None would compile (the struct literal forces it to be listed) yet silently drop from --generate-config output. Compares key-paths of a fully-populated Config against the example.
- Add .github/workflows/integration.yml: the 21 #[ignore] network tests run on a weekly schedule + manual dispatch (kept off the PR path so flaky external responders never block merges); llvm-cov line coverage of the offline suite runs on push/PR, uploaded as an artifact and summarized.