### PR TITLE
feat: add connection timeout feature with configurable budget for host connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,20 @@ Descriptive, changeable metadata therefore lives on a dedicated info metric, `tl
 tlschecker_days_before_expired * on(instance) group_left(grade, issuer) tlschecker_certificate_info
 ```
 
+### Connection Timeout
+
+Each host gets 30 seconds to connect by default. Use `--connect-timeout` to change that budget (1–3600 seconds):
+
+```sh
+➜ tlschecker --connect-timeout 5 example.com internal.example.com
+```
+
+The value is the budget for the **connect phase of one host** — shared across every address the hostname resolves to — and is also applied as the socket read timeout during the handshake. Because each check occupies a worker thread, lowering it keeps a large host list moving when some hosts are unreachable; raise it for slow links.
+
+It is deliberately named for what it bounds: it does **not** cap the whole check. `--check-revocation` (OCSP and each CRL distribution point) and `--ct-check` keep their own separate timeouts, and `--scan` caps its per-handshake wait at 10 seconds regardless of this setting, since a scan performs on the order of a hundred connections. Note that lowering the timeout can make `--scan` report a protocol as unsupported when the probe merely timed out.
+
+Hostnames that resolve to several addresses (an A and a AAAA record, or a pool of load-balanced servers) are tried **in resolution order until one accepts**, so a host that is up on one of its addresses is not reported as unreachable just because the first address it resolves to is not. This matters most on IPv4-only networks whose resolver still returns AAAA records.
+
 ### Certificate Fingerprints
 
 Every check reports the SHA-256 and SHA-1 fingerprints of the leaf certificate (colon-separated uppercase hex, the same format as browsers and `openssl x509 -fingerprint`). They appear in `text` and `json` output and are useful for certificate pinning and comparison.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1308,10 +1308,7 @@ fn resolve_addrs(host: &str, port: u16) -> Result<Vec<SocketAddr>, TLSError> {
 ///
 /// Returns the last connection error when every address fails, so the reported
 /// reason describes an actual attempt rather than a synthesized message.
-fn connect_first_available(
-    addrs: &[SocketAddr],
-    timeout: Duration,
-) -> Result<TcpStream, TLSError> {
+fn connect_first_available(addrs: &[SocketAddr], timeout: Duration) -> Result<TcpStream, TLSError> {
     let deadline = Instant::now() + timeout;
     let mut last_err: Option<std::io::Error> = None;
 
@@ -1326,7 +1323,10 @@ fn connect_first_available(
             Ok(stream) => return Ok(stream),
             Err(err) => {
                 if addrs.len() > 1 {
-                    warn!("Connection to {} failed: {}; trying next address", addr, err);
+                    warn!(
+                        "Connection to {} failed: {}; trying next address",
+                        addr, err
+                    );
                 }
                 last_err = Some(err);
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,8 @@ pub mod probe;
 pub mod sct;
 
 use std::fmt::Debug;
-use std::time::Duration;
+use std::net::{SocketAddr, TcpStream, ToSocketAddrs};
+use std::time::{Duration, Instant};
 
 use openssl::asn1::{Asn1Time, Asn1TimeRef};
 use openssl::error::ErrorStack;
@@ -46,7 +47,10 @@ use thiserror::Error;
 use tracing::{instrument, warn};
 
 /// Default timeout for TLS connection attempts (30 seconds).
-static TIMEOUT: Duration = Duration::from_secs(30);
+///
+/// Used by [`TLS::from`]; callers that need a different budget go through
+/// [`TLS::from_with_timeout`].
+pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Revocation Status
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -1268,17 +1272,133 @@ fn is_crl_fresh(crl: &X509Crl, source: &str) -> bool {
     }
 }
 
+/// Resolves `host:port` and returns every address DNS reports, in resolution
+/// order.
+///
+/// Resolution is done through the `(host, port)` tuple rather than a
+/// `"{host}:{port}"` string so IPv6 literals (e.g. `::1`) work without bracket
+/// syntax.
+fn resolve_addrs(host: &str, port: u16) -> Result<Vec<SocketAddr>, TLSError> {
+    let addrs: Vec<SocketAddr> = (host, port).to_socket_addrs()?.collect();
+    if addrs.is_empty() {
+        return Err(TLSError::DNS(format!(
+            "No addresses resolved for '{}'",
+            host
+        )));
+    }
+    Ok(addrs)
+}
+
+/// Connects to the first address in `addrs` that accepts, within a total
+/// `timeout` budget shared across all attempts.
+///
+/// A hostname commonly resolves to several addresses — an A and a AAAA record,
+/// or a pool of load-balanced servers. Trying only the first makes a check fail
+/// whenever that single address is unreachable even though the host is happily
+/// serving on another, which is exactly what happens on an IPv4-only network
+/// whose resolver still returns the AAAA record first.
+///
+/// The `timeout` is the budget for the *whole* connect phase, not per address:
+/// that keeps the worst case bounded at the value the caller asked for no
+/// matter how many addresses DNS returns, which matters because each check
+/// occupies a worker thread. This costs nothing in the case that motivates
+/// trying several addresses — an unroutable address family or a refused
+/// connection fails immediately rather than burning the budget — while a
+/// genuinely blackholed first address will still consume it.
+///
+/// Returns the last connection error when every address fails, so the reported
+/// reason describes an actual attempt rather than a synthesized message.
+fn connect_first_available(
+    addrs: &[SocketAddr],
+    timeout: Duration,
+) -> Result<TcpStream, TLSError> {
+    let deadline = Instant::now() + timeout;
+    let mut last_err: Option<std::io::Error> = None;
+
+    for addr in addrs {
+        // `connect_timeout` rejects a zero duration, and no budget left means
+        // there is nothing useful to do anyway.
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        match TcpStream::connect_timeout(addr, remaining) {
+            Ok(stream) => return Ok(stream),
+            Err(err) => {
+                if addrs.len() > 1 {
+                    warn!("Connection to {} failed: {}; trying next address", addr, err);
+                }
+                last_err = Some(err);
+            }
+        }
+    }
+
+    Err(match last_err {
+        Some(err) => TLSError::Connection(err),
+        // Only reachable when the budget was already spent before the first
+        // attempt, so no attempt ever produced an error.
+        None => TLSError::Connection(std::io::Error::new(
+            std::io::ErrorKind::TimedOut,
+            "connection timed out before any address could be tried",
+        )),
+    })
+}
+
 impl TLS {
-    #[instrument]
+    /// Establishes a TLS connection and inspects the presented certificate,
+    /// using the default 30-second connection budget.
+    ///
+    /// See [`TLS::from_with_timeout`] for the full description; this is that
+    /// function with [`DEFAULT_TIMEOUT`].
     pub fn from(
         host: &str,
         port: Option<u16>,
         check_revocation: bool,
         calculate_grade: bool,
     ) -> Result<TLS, TLSError> {
+        TLS::from_with_timeout(
+            host,
+            port,
+            check_revocation,
+            calculate_grade,
+            DEFAULT_TIMEOUT,
+        )
+    }
+
+    /// Establishes a TLS connection and inspects the presented certificate,
+    /// bounding the connect phase by `timeout`.
+    ///
+    /// `timeout` is the budget for connecting (shared across every address the
+    /// hostname resolves to — see [`connect_first_available`]) and is also
+    /// applied as the socket read timeout, so a server that accepts the TCP
+    /// connection but never completes the handshake cannot block indefinitely.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use std::time::Duration;
+    /// use tlschecker::TLS;
+    ///
+    /// let result = TLS::from_with_timeout(
+    ///     "example.com",
+    ///     None,
+    ///     false,
+    ///     false,
+    ///     Duration::from_secs(5),
+    /// )?;
+    /// println!("Expires in {} days", result.certificate.validity_days);
+    /// # Ok::<(), tlschecker::TLSError>(())
+    /// ```
+    #[instrument]
+    pub fn from_with_timeout(
+        host: &str,
+        port: Option<u16>,
+        check_revocation: bool,
+        calculate_grade: bool,
+        timeout: Duration,
+    ) -> Result<TLS, TLSError> {
         use openssl::nid::Nid;
         use openssl::ssl::{Ssl, SslContext, SslMethod, SslVerifyMode};
-        use std::net::{TcpStream, ToSocketAddrs};
 
         // Trim any whitespace, and strip brackets that wrap IPv6 literals
         // (e.g. "[::1]" -> "::1") so address resolution and hostname matching
@@ -1307,16 +1427,12 @@ impl TLS {
 
         // Use the provided port or default to 443
         let port = port.unwrap_or(443);
-        // Resolve via the (host, port) tuple rather than "{host}:{port}" so IPv6
-        // literals (e.g. "::1") work without bracket syntax.
-        let socket_addr = (host, port)
-            .to_socket_addrs()?
-            .next()
-            .ok_or_else(|| TLSError::DNS("Failed parse remote hostname".to_string()))?;
+        // Try every resolved address rather than only the first, so a host that
+        // is up on one of its addresses is not reported as unreachable.
+        let addrs = resolve_addrs(host, port)?;
+        let tcp_stream = connect_first_available(&addrs, timeout)?;
 
-        let tcp_stream = TcpStream::connect_timeout(&socket_addr, TIMEOUT)?;
-
-        tcp_stream.set_read_timeout(Some(TIMEOUT))?;
+        tcp_stream.set_read_timeout(Some(timeout))?;
         let stream = connector.connect(tcp_stream)?;
 
         // `Ssl` object associated with this stream
@@ -1952,9 +2068,94 @@ mod tests {
     use crate::grading;
     use crate::probe::ProtoVersion;
     use crate::{
-        CertificateInfo, Chain, Cipher, Issuer, RevocationStatus, SecurityWarning, Subject,
-        TLSError, TrustStatus, TLS,
+        connect_first_available, resolve_addrs, CertificateInfo, Chain, Cipher, Issuer,
+        RevocationStatus, SecurityWarning, Subject, TLSError, TrustStatus, TLS,
     };
+    use std::net::{SocketAddr, TcpListener};
+    use std::time::Duration;
+
+    /// Binds a loopback listener and returns it with its address. The listener
+    /// is never accepted from; the kernel backlog is enough for a connect to
+    /// succeed, which is all these tests need.
+    fn live_addr() -> (TcpListener, SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+        let addr = listener.local_addr().expect("local addr");
+        (listener, addr)
+    }
+
+    /// Returns a loopback address with nothing listening on it, by binding a
+    /// port and immediately releasing it. Connecting there is refused
+    /// immediately rather than timing out, which is the fast-failure case
+    /// multi-address connect relies on.
+    fn dead_addr() -> SocketAddr {
+        let (listener, addr) = live_addr();
+        drop(listener);
+        addr
+    }
+
+    #[test]
+    fn test_resolve_addrs_returns_loopback() {
+        let addrs = resolve_addrs("127.0.0.1", 443).expect("loopback resolves");
+        assert_eq!(addrs, vec!["127.0.0.1:443".parse::<SocketAddr>().unwrap()]);
+    }
+
+    /// Network test: `to_socket_addrs` calls the system resolver, so this is
+    /// gated like the other network tests. It is not merely slow — a resolver
+    /// that hijacks NXDOMAIN (ISP "search assist", captive portals, corporate
+    /// wildcard DNS) answers `.invalid` with a real address and fails the
+    /// assertion, which would make `cargo test` red because of the tester's
+    /// network rather than the code.
+    #[test]
+    #[ignore]
+    fn test_resolve_addrs_unresolvable_host_errors() {
+        // `.invalid` is reserved by RFC 2606 and must never resolve.
+        let err = resolve_addrs("nonexistent.invalid", 443);
+        assert!(err.is_err(), "reserved .invalid TLD must not resolve");
+    }
+
+    #[test]
+    fn test_connect_uses_first_reachable_address() {
+        let (_listener, live) = live_addr();
+        let dead = dead_addr();
+
+        // The reachable address is deliberately last: taking only the first
+        // resolved address (the old behaviour) would fail here.
+        let stream = connect_first_available(&[dead, live], Duration::from_secs(5))
+            .expect("should fall through to the reachable address");
+        assert_eq!(stream.peer_addr().unwrap(), live);
+    }
+
+    #[test]
+    fn test_connect_prefers_earlier_address_when_reachable() {
+        let (_first, first_addr) = live_addr();
+        let (_second, second_addr) = live_addr();
+
+        let stream = connect_first_available(&[first_addr, second_addr], Duration::from_secs(5))
+            .expect("first address is reachable");
+        assert_eq!(
+            stream.peer_addr().unwrap(),
+            first_addr,
+            "resolution order must be preserved"
+        );
+    }
+
+    #[test]
+    fn test_connect_all_addresses_fail_reports_connection_error() {
+        let addrs = [dead_addr(), dead_addr()];
+        let err = connect_first_available(&addrs, Duration::from_secs(5))
+            .expect_err("no address is reachable");
+        assert!(
+            matches!(err, TLSError::Connection(_)),
+            "expected a connection error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn test_connect_with_no_addresses_errors() {
+        let err = connect_first_available(&[], Duration::from_secs(5))
+            .expect_err("nothing to connect to");
+        assert!(matches!(err, TLSError::Connection(_)));
+    }
 
     /// Creates a synthetic TLS struct for offline testing.
     /// No network connection needed — all fields are populated with realistic data.

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use std::io::IsTerminal;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::thread;
+use std::time::Duration;
 mod config;
 mod metrics;
 mod tui;
@@ -120,6 +121,19 @@ struct Args {
     /// --exit-code, so CI pipelines can catch hosts that are down entirely.
     #[arg(long)]
     fail_on_error: bool,
+
+    /// Seconds to spend connecting to each host before giving up [default: 30].
+    ///
+    /// This is the budget for the connect phase of one host — shared across
+    /// every address its hostname resolves to — and is also applied as the
+    /// socket read timeout during the handshake. Lower it to keep a large host
+    /// list moving when some hosts are unreachable; raise it for slow links.
+    ///
+    /// It does NOT bound the whole check: --check-revocation (OCSP/CRL) and
+    /// --ct-check keep their own timeouts, and --scan caps its per-handshake
+    /// wait at 10s since it performs many connections.
+    #[arg(long, value_name = "SECONDS")]
+    connect_timeout: Option<u64>,
 
     /// Look the presented leaf certificate up in public Certificate
     /// Transparency logs (via crt.sh).
@@ -790,6 +804,31 @@ impl FinalConfig {
 /// machine's available parallelism or the number of hosts.
 const MAX_CONCURRENT_CHECKS: usize = 16;
 
+/// Largest accepted `--connect-timeout`. Anything beyond an hour is a typo
+/// rather than an intent, and the value must stay small enough that adding it
+/// to an `Instant` cannot overflow — `Instant + Duration` panics on overflow,
+/// so an unbounded value would crash the worker instead of failing validation.
+const MAX_CONNECT_TIMEOUT_SECS: u64 = 3600;
+
+/// Turns the optional `--connect-timeout` value into a [`Duration`], falling
+/// back to the library default when it was not given.
+///
+/// Both ends are rejected rather than clamped silently. Zero would make every
+/// check fail instantly, which reads as a network outage rather than a
+/// misconfiguration; an out-of-range upper value is a typo worth reporting
+/// (and, left unchecked, would overflow the deadline arithmetic and panic).
+fn resolve_connect_timeout(seconds: Option<u64>) -> Result<Duration, String> {
+    match seconds {
+        None => Ok(tlschecker::DEFAULT_TIMEOUT),
+        Some(0) => Err("--connect-timeout must be at least 1 second".to_string()),
+        Some(secs) if secs > MAX_CONNECT_TIMEOUT_SECS => Err(format!(
+            "--connect-timeout must be at most {} seconds (got {})",
+            MAX_CONNECT_TIMEOUT_SECS, secs
+        )),
+        Some(secs) => Ok(Duration::from_secs(secs)),
+    }
+}
+
 /// Checks a single host: TLS connection plus the optional scan and CT lookup.
 ///
 /// Returns the error unlogged so each frontend can present it its own way:
@@ -797,15 +836,20 @@ const MAX_CONCURRENT_CHECKS: usize = 16;
 fn check_host(host_port: &HostPort, opts: CheckOptions) -> Result<TLS, TLSError> {
     let port_display = host_port.port.map_or(String::new(), |p| format!(":{}", p));
 
-    let mut cert = TLS::from(
+    let mut cert = TLS::from_with_timeout(
         &host_port.host,
         host_port.port,
         opts.check_revocation,
         opts.calculate_grade,
+        opts.connect_timeout,
     )?;
 
     if opts.do_scan {
-        if let Ok(scan) = tlschecker::probe::scan_tls(&host_port.host, host_port.port) {
+        if let Ok(scan) = tlschecker::probe::scan_tls_with_timeout(
+            &host_port.host,
+            host_port.port,
+            opts.connect_timeout,
+        ) {
             // Fold scan-derived warnings into the result and
             // recompute the grade to reflect full posture.
             cert.apply_scan(scan);
@@ -839,6 +883,8 @@ struct CheckOptions {
     calculate_grade: bool,
     do_scan: bool,
     do_ct: bool,
+    /// Budget for the connect phase of a single host (see `--connect-timeout`).
+    connect_timeout: Duration,
 }
 
 /// The result of attempting to check one host.
@@ -1003,7 +1049,16 @@ fn main() -> Result<()> {
         .collect();
     let hosts_len = jobs.len();
 
+    let connect_timeout = match resolve_connect_timeout(cli.connect_timeout) {
+        Ok(timeout) => timeout,
+        Err(msg) => {
+            error!("{}", msg);
+            std::process::exit(1);
+        }
+    };
+
     let opts = CheckOptions {
+        connect_timeout,
         check_revocation: final_config.check_revocation,
         // `--scan` implies `--grade` (the scan is surfaced via the grade), and
         // the dashboard always grades: its detail pane shows the breakdown and
@@ -1290,6 +1345,48 @@ pub(crate) mod tests {
         let hp = parse_host_port("example.com:8443").unwrap();
         assert_eq!(hp.host, "example.com");
         assert_eq!(hp.port, Some(8443));
+    }
+
+    #[test]
+    fn test_resolve_connect_timeout_defaults_when_unset() {
+        assert_eq!(
+            resolve_connect_timeout(None).unwrap(),
+            tlschecker::DEFAULT_TIMEOUT
+        );
+    }
+
+    #[test]
+    fn test_resolve_connect_timeout_uses_supplied_seconds() {
+        assert_eq!(
+            resolve_connect_timeout(Some(5)).unwrap(),
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn test_resolve_connect_timeout_rejects_zero() {
+        // Zero would make every check fail instantly and read as an outage.
+        assert!(resolve_connect_timeout(Some(0)).is_err());
+    }
+
+    #[test]
+    fn test_resolve_connect_timeout_accepts_upper_bound() {
+        assert_eq!(
+            resolve_connect_timeout(Some(MAX_CONNECT_TIMEOUT_SECS)).unwrap(),
+            Duration::from_secs(MAX_CONNECT_TIMEOUT_SECS)
+        );
+    }
+
+    #[test]
+    fn test_resolve_connect_timeout_rejects_above_upper_bound() {
+        assert!(resolve_connect_timeout(Some(MAX_CONNECT_TIMEOUT_SECS + 1)).is_err());
+    }
+
+    #[test]
+    fn test_resolve_connect_timeout_rejects_overflowing_value() {
+        // `Instant + Duration` panics on overflow, so an unbounded value would
+        // crash a worker thread instead of failing validation.
+        assert!(resolve_connect_timeout(Some(u64::MAX)).is_err());
     }
 
     #[test]

--- a/src/probe.rs
+++ b/src/probe.rs
@@ -9,7 +9,7 @@
 //! This is opt-in (`--scan`) because it opens many short-lived connections and
 //! is therefore slower than a normal certificate check.
 
-use std::net::{TcpStream, ToSocketAddrs};
+use std::net::TcpStream;
 use std::time::Duration;
 
 use openssl::ssl::{Ssl, SslContext, SslMethod, SslVerifyMode, SslVersion};
@@ -82,8 +82,12 @@ impl<'de> Deserialize<'de> for ProtoVersion {
     }
 }
 
-/// Per-handshake timeout while probing. Kept short since a scan performs many
-/// connection attempts.
+/// Upper bound on the per-handshake timeout while probing. Kept short since a
+/// scan performs many connection attempts: honouring a long connect timeout for
+/// each of them would make a scan of an unresponsive host take minutes.
+///
+/// A caller-supplied timeout narrows this (see [`scan_tls_with_timeout`]) but
+/// never raises it.
 const PROBE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Candidate cipher suites for TLS 1.2 and below, including a few deliberately
@@ -161,6 +165,7 @@ fn try_handshake(
     version: SslVersion,
     cipher_list: Option<&str>,
     ciphersuites: Option<&str>,
+    timeout: Duration,
 ) -> Option<String> {
     let mut ctx = SslContext::builder(SslMethod::tls()).ok()?;
     ctx.set_verify(SslVerifyMode::empty());
@@ -180,9 +185,9 @@ fn try_handshake(
     let mut ssl = Ssl::new(&ctx).ok()?;
     ssl.set_hostname(host).ok()?;
 
-    let tcp = TcpStream::connect_timeout(&addr, PROBE_TIMEOUT).ok()?;
-    tcp.set_read_timeout(Some(PROBE_TIMEOUT)).ok()?;
-    tcp.set_write_timeout(Some(PROBE_TIMEOUT)).ok()?;
+    let tcp = TcpStream::connect_timeout(&addr, timeout).ok()?;
+    tcp.set_read_timeout(Some(timeout)).ok()?;
+    tcp.set_write_timeout(Some(timeout)).ok()?;
 
     let stream = ssl.connect(tcp).ok()?;
     stream.ssl().current_cipher().map(|c| c.name().to_string())
@@ -204,8 +209,23 @@ fn try_handshake(
 /// A [`TlsScan`] describing per-version support, [`TLSError::Validation`] if
 /// the hostname is empty, or a connection/DNS error when the host does not
 /// resolve.
-#[instrument]
 pub fn scan_tls(host: &str, port: Option<u16>) -> Result<TlsScan, TLSError> {
+    scan_tls_with_timeout(host, port, PROBE_TIMEOUT)
+}
+
+/// [`scan_tls`] with a caller-supplied per-handshake timeout.
+///
+/// The timeout is capped at [`PROBE_TIMEOUT`]: a scan issues on the order of a
+/// hundred handshakes, so a long connect budget that is reasonable for a single
+/// check would make a scan of a black-holed host take minutes. Lowering the
+/// timeout below the cap does take effect, which is how `--timeout` speeds up
+/// scans of hosts known to be fast.
+#[instrument]
+pub fn scan_tls_with_timeout(
+    host: &str,
+    port: Option<u16>,
+    timeout: Duration,
+) -> Result<TlsScan, TLSError> {
     // Strip IPv6 brackets so "[::1]" resolves like the bare "::1", and
     // convert IDN hostnames to their ASCII form for resolution.
     let host = crate::to_ascii_hostname(crate::unbracket_host(host.trim()));
@@ -214,27 +234,30 @@ pub fn scan_tls(host: &str, port: Option<u16>) -> Result<TlsScan, TLSError> {
         return Err(TLSError::Validation("Hostname cannot be empty".to_string()));
     }
     let port = port.unwrap_or(443);
+    let timeout = timeout.min(PROBE_TIMEOUT);
 
-    // Resolve once up front: a scan performs on the order of a hundred
-    // handshake attempts, and per-attempt resolution would both hammer the
-    // resolver and risk probing different IPs of a multi-address host,
-    // making per-version results incoherent.
-    let addr = (host, port)
-        .to_socket_addrs()
-        .map_err(TLSError::Connection)?
-        .next()
-        .ok_or_else(|| TLSError::DNS("Failed parse remote hostname".to_string()))?;
+    // Resolve and pick a reachable address once up front, then pin it: a scan
+    // performs on the order of a hundred handshake attempts, and re-resolving
+    // per attempt would both hammer the resolver and risk probing different IPs
+    // of a multi-address host, making per-version results incoherent. Picking
+    // the address by actually connecting (rather than taking the first DNS
+    // answer) means a host whose first address is unreachable still gets
+    // scanned on the address that works.
+    let addrs = crate::resolve_addrs(host, port)?;
+    let addr = crate::connect_first_available(&addrs, timeout)?.peer_addr()?;
 
     let mut protocols = Vec::with_capacity(VERSIONS.len());
     for &(ssl_version, version) in VERSIONS {
         // Is this version accepted at all (with a default cipher selection)?
-        let supported = try_handshake(host, addr, ssl_version, None, None).is_some();
+        let supported = try_handshake(host, addr, ssl_version, None, None, timeout).is_some();
 
         let mut ciphers = Vec::new();
         if supported {
             if ssl_version == SslVersion::TLS1_3 {
                 for suite in TLS13_CIPHERS {
-                    if let Some(name) = try_handshake(host, addr, ssl_version, None, Some(suite)) {
+                    if let Some(name) =
+                        try_handshake(host, addr, ssl_version, None, Some(suite), timeout)
+                    {
                         if !ciphers.contains(&name) {
                             ciphers.push(name);
                         }
@@ -242,7 +265,9 @@ pub fn scan_tls(host: &str, port: Option<u16>) -> Result<TlsScan, TLSError> {
                 }
             } else {
                 for cipher in LEGACY_CIPHERS {
-                    if let Some(name) = try_handshake(host, addr, ssl_version, Some(cipher), None) {
+                    if let Some(name) =
+                        try_handshake(host, addr, ssl_version, Some(cipher), None, timeout)
+                    {
                         if !ciphers.contains(&name) {
                             ciphers.push(name);
                         }


### PR DESCRIPTION
## Summary

Two related connection-layer changes:

1. **Try every resolved address**, not just the first, so a host that is up on one of its IPs is no longer reported as unreachable.
2. **`--connect-timeout`**, making the previously hardcoded 30s connect budget configurable.

## Multi-address connect

`TLS::from` resolved with `to_socket_addrs()` and took `.next()`. A hostname commonly resolves to several addresses — an A and a AAAA record, or a pool of load-balanced servers — so a single unreachable address failed the whole check. The common trigger is an IPv4-only network whose resolver still returns the AAAA record first.

Resolution and connection are now split into `resolve_addrs` (returns every address) and `connect_first_available` (tries them in resolution order until one accepts), shared by `lib.rs` and `probe.rs`.

**The timeout is the budget for the whole connect phase, not per address.** This bounds the worst case at the value the caller asked for regardless of how many addresses DNS returns, which matters because each check occupies one of at most 16 worker threads. It costs nothing in the case that motivates the fallback — an unroutable address family or a refused connection fails immediately without consuming budget. The tradeoff is that a genuinely blackholed first address still consumes the budget, so the fallback helps with fast failures, not with silent drops.

When every address fails, the *last* connection error is returned, so the reported reason describes a real attempt.

`probe.rs` now picks its target address by actually connecting rather than taking the first DNS answer, then pins it for all ~100 handshakes.

## `--connect-timeout <SECONDS>`

Range 1–3600, default 30.

```sh
tlschecker --connect-timeout 5 example.com internal.example.com
```

It bounds the connect phase (shared across addresses) and the socket read timeout during the handshake. It is named for what it bounds and deliberately **not** `--timeout`: it does not cap the whole check. `--check-revocation` (OCSP, plus each CRL distribution point) and `--ct-check` keep their own separate timeouts, so per-host wall time can still exceed it. `--scan` caps its per-handshake wait at 10s regardless, since a long budget across ~100 handshakes would take minutes.

Both ends of the range are rejected rather than clamped silently: `0` would make every check fail instantly and read as a network outage rather than a misconfiguration, and an out-of-range upper value is a typo worth reporting. The upper bound is also load-bearing — `Instant + Duration` panics on overflow, so an unvalidated value would crash a worker thread instead of failing validation.

## Public API

Additive; existing callers are unaffected.

- `TLS::from_with_timeout(host, port, check_revocation, calculate_grade, timeout)` — new
- `probe::scan_tls_with_timeout(host, port, timeout)` — new
- `DEFAULT_TIMEOUT` — new (30s)
- `TLS::from(...)` and `probe::scan_tls(...)` unchanged, now delegating with the default

The library entry points keep the name `timeout` because there the value genuinely covers connect *and* reads; only the CLI flag is `--connect-timeout`, following the `curl --connect-timeout` convention.

## Tests

130 lib + 132 bin + 6 doc tests pass; 21 network tests pass under `-- --ignored`. Clippy clean.

New offline coverage uses real loopback sockets (one listener live, one with its port released so the connect is refused immediately): resolution order preserved, fallback to a later address, all-addresses-fail, empty address list, plus `resolve_connect_timeout` bounds including the overflow value.

## Known limitations

Not addressed here, flagged for follow-up:

- **`--scan` cannot distinguish a timed-out probe from a refused one.** `try_handshake` maps every failure to `None`, so lowering `--connect-timeout` against a slow server can report a protocol as unsupported when it is merely slow. A host genuinely offering TLS 1.0 could then skip the C-max grade cap and score an A.
- **The scan re-resolves independently of the certificate check**, so on a round-robin hostname the cert and the protocol/cipher findings can come from different servers yet be merged into one result. This predates the change, but the fix is now cheap: `check_host` could pass down the address it already connected to.
- **`--connect-timeout` does not bound OCSP/CRL/crt.sh**, as described above.

## Note

The `CLAUDE.md` architecture notes for these changes are still uncommitted locally and are **not** part of this PR.
